### PR TITLE
Migrate to official pycqa/flake8 hooks repo

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.0.0
+    rev: v2.1.0
     hooks:
     -   id: trailing-whitespace
     -   id: end-of-file-fixer
@@ -8,13 +8,16 @@ repos:
     -   id: check-xml
     -   id: check-yaml
     -   id: debug-statements
+-   repo: https://gitlab.com/pycqa/flake8
+    rev: 3.7.1
+    hooks:
     -   id: flake8
 -   repo: https://github.com/pre-commit/mirrors-autopep8
-    rev: v1.4
+    rev: v1.4.3
     hooks:
     -   id: autopep8
 -   repo: https://github.com/asottile/reorder_python_imports
-    rev: v1.3.0
+    rev: v1.3.5
     hooks:
     -   id: reorder-python-imports
         args: [--py3-plus]
@@ -34,7 +37,7 @@ repos:
             --no-arrow_on_right_operand_line-check,
         ]
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.630
+    rev: v0.660
     hooks:
     -   id: mypy
 -   repo: local


### PR DESCRIPTION
Committed via https://github.com/asottile/all-repos